### PR TITLE
Fix issue with flags when a switch value is enclosed in quotes

### DIFF
--- a/fzf-key-bindings.bash
+++ b/fzf-key-bindings.bash
@@ -63,7 +63,7 @@ __fzf_sfdx_flags__(){
   local selected="$1"
   local fullcmd=""
   for i in "${@:2}"
-  do fullcmd+=" $i"
+  do fullcmd+=" ${i//\"/\\\\\\\"}" #we have to triple escape the double quotes here as it will be used within double quotes again in the command below
   done
   local ret=`cat ~/.sfdxcommands.json | jq -r ".[] | select(.id==\"$selected\") | .flags | keys[]" | $(__fzfcmd) -m --bind 'ctrl-z:ignore,alt-j:preview-down,alt-k:preview-up' --preview='cat ~/.sfdxcommands.json | jq -r ".[] | select(.id==\"'$selected'\") | .flags | to_entries[] | select (.key==\""{}"\") | [\"Command:\n'"$fullcmd"'\n\",\"Flag Description:\",.value][]"' --preview-window='right:wrap'`
   echo "${ret//$'\n'/ --}"

--- a/fzf-key-bindings.zsh
+++ b/fzf-key-bindings.zsh
@@ -113,7 +113,7 @@ __fzf_sfdx_flags(){
   local selected="$1"
   local fullcmd=""
   for i in "${@:2}"
-  do fullcmd+=" $i"
+  do fullcmd+=" ${i//\"/\\\\\\\"}" #we have to triple escape the double quotes here as it will be used within double quotes again in the command below
   done
   local ret=`cat ~/.sfdxcommands.json | jq -r ".[] | select(.id==\"$selected\") | .flags | keys[]" | $(__fzfcmd) -m --bind='ctrl-z:ignore,alt-j:preview-down,alt-k:preview-up' --preview='cat ~/.sfdxcommands.json | jq -r ".[] | select(.id==\"'$selected'\") | .flags | to_entries[] | select (.key==\""{}"\") | [\"Command:\n'"$fullcmd"'\n\",\"Flag Description:\",.value][]"' --preview-window='right:wrap'`
   echo "${ret//$'\n'/ --}"


### PR DESCRIPTION
When a flag's value is enclosed in quotes, the command was breaking due
to lack of an escape sequence. The issue has been fixed.